### PR TITLE
feat(config): add Ollama model selection to configuration

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -39,17 +39,18 @@ impl Agent {
     /// * `personality` - Personality traits of the agent.
     /// * `initial_energy` - Starting energy level.
     /// * `initial_position` - Initial (x, y) coordinates.
+    /// * `ollama_model` - The Ollama model to be used by the agent.
     ///
     /// # Returns
     /// * A new `Agent` instance.
-    pub fn new(name: String, personality: Personality, initial_energy: f32) -> Self {
+    pub fn new(name: String, personality: Personality, initial_energy: f32, ollama_model: String) -> Self {
         Self {
             name,
             state: AgentState::Idle,
             energy: initial_energy,
             personality,
             conversation_history: Vec::new(),
-            ollama_model: "llama3.2:latest".to_string(), // Default model
+            ollama_model, // Use the provided model
             next_prompt: String::new(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
 
     /// Debug mode flag (enables additional logging and debugging features).
     pub debug: bool,
+
+    /// The Ollama model to use.
+    pub ollama_model: Option<String>,
 }
 
 /// Defines the world parameters for the simulation.
@@ -81,6 +84,7 @@ impl Config {
                 },
             ],
             debug: true,
+            ollama_model: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,12 @@ use crate::ui::UI;
 use std::path::Path;
 use std::sync::mpsc;
 use std::thread;
+use std::io::{self, Write};
 
 fn main() {
     // Load configuration file
     let config_path = Path::new("config.json");
-    let config = match Config::load(config_path) {
+    let mut config = match Config::load(config_path) {
         Ok(config) => config,
         Err(e) => {
             eprintln!("Error loading configuration: {}", e);
@@ -29,6 +30,65 @@ fn main() {
             config
         }
     };
+
+    if config.ollama_model.is_none() {
+        println!("No Ollama model configured. Please choose a model from the list below:");
+        let output = std::process::Command::new("ollama")
+            .arg("list")
+            .output();
+
+        match output {
+            Ok(output) => {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let models: Vec<String> = stdout
+                        .lines()
+                        .skip(1) // Skip header line
+                        .filter_map(|line| line.split_whitespace().next().map(String::from))
+                        .collect();
+
+                    if models.is_empty() {
+                        eprintln!("No Ollama models found. Please ensure Ollama is running and models are installed.");
+                        // Optionally, set a default or exit
+                        config.ollama_model = Some("default".to_string()); // Or handle error appropriately
+                    } else {
+                        for (i, model_name) in models.iter().enumerate() {
+                            println!("{}: {}", i + 1, model_name);
+                        }
+                        loop {
+                            print!("Select model number: ");
+                            io::stdout().flush().unwrap();
+                            let mut selection = String::new();
+                            io::stdin().read_line(&mut selection).unwrap();
+                            match selection.trim().parse::<usize>() {
+                                Ok(n) if n > 0 && n <= models.len() => {
+                                    config.ollama_model = Some(models[n - 1].clone());
+                                    if let Err(e) = config.save(config_path) {
+                                        eprintln!("Error saving configuration: {}", e);
+                                    }
+                                    println!("Selected model: {}", models[n - 1]);
+                                    break;
+                                }
+                                _ => {
+                                    println!("Invalid selection. Please try again.");
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("Error listing Ollama models: {}", stderr);
+                    // Optionally, set a default or exit
+                    config.ollama_model = Some("default".to_string()); // Or handle error appropriately
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute 'ollama list': {}. Please ensure Ollama is installed and in your PATH.", e);
+                // Optionally, set a default or exit
+                config.ollama_model = Some("default".to_string()); // Or handle error appropriately
+            }
+        }
+    }
 
     // Create communication channels
     let (ui_tx, sim_rx) = mpsc::channel();

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -58,18 +58,21 @@ impl Simulation {
 
         // Initialize agents based on configuration
         let mut agents = HashMap::new();
+        let ollama_model_name = config.ollama_model.clone().unwrap_or_else(|| {
+            eprintln!("Warning: Ollama model not found in config, using default.");
+            "llama3.2:latest".to_string() // Fallback to a default if not in config
+        });
+
         for agent_config in &config.agents {
             let id = Uuid::new_v4().to_string();
             let personality = get_personality_template(&agent_config.personality_template);
 
-            let mut agent = Agent::new(
+            let agent = Agent::new(
                 agent_config.name.clone(),
                 personality,
                 agent_config.initial_energy,
+                ollama_model_name.clone(), // Pass the model name from config
             );
-
-            // Set the Ollama model (this could be added to the config later)
-            agent.set_model("llama3.2:latest".to_string());
 
             agents.insert(id, agent);
         }


### PR DESCRIPTION
This pull request introduces support for configuring and selecting the Ollama model used by agents in the simulation. The changes include updates to the `Agent`, `Config`, and `Simulation` classes, as well as enhancements to the `main` function to allow dynamic model selection if none is preconfigured.

### Enhancements for Ollama model configuration:

* [`src/agent.rs`](diffhunk://#diff-3bab5cd53a1040a4a531afe1501403786256e9dea8731dc20028c9beabddd2d3R42-R53): Updated the `Agent::new` constructor to accept an `ollama_model` parameter, removing the hardcoded default model.
* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR19-R21): Added an `ollama_model` field to the `Config` struct and initialized it as `None` in the default configuration. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR19-R21) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR87)

### Dynamic model selection in the main program:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR19-R24): Enhanced the `main` function to prompt the user to select an Ollama model if none is configured. The available models are retrieved using the `ollama list` command, and the user's selection is saved back to the configuration file. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR19-R24) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR34-R92)

### Integration of the selected model into simulations:

* [`src/simulation.rs`](diffhunk://#diff-aebe6b2eb6db90e238cfad68f4546e4d61f3c81cb5a7501104aecd737ee99865R61-L73): Updated the `Simulation` initialization to retrieve the configured Ollama model from `Config`. If no model is found, a default model is used as a fallback. The selected model is passed to each `Agent` during creation.